### PR TITLE
feat: add github link to footer with lucide icon

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,4 +1,6 @@
 import { ComponentProps } from "react";
+import { Github } from "lucide-react";
+import Link from "next/link";
 
 const Footer = ({
   className,
@@ -6,7 +8,17 @@ const Footer = ({
 }: Omit<ComponentProps<"footer">, "children">) => {
   return (
     <footer className={"border-t py-3 " + className} {...props}>
-      <div></div>
+      <div className="container mx-auto flex justify-center px-4">
+        <Link
+          href="https://github.com/imfelixyeung/temporal.feli.page"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+        >
+          <Github size={18} />
+          <span className="text-sm">GitHub</span>
+        </Link>
+      </div>
     </footer>
   );
 };


### PR DESCRIPTION
## Summary
- Add GitHub link to the footer that points to https://github.com/imfelixyeung/temporal.feli.page
- Use lucide-react Github icon with proper styling
- Implement with Tailwind CSS for clean, responsive design
- Add hover effects and proper accessibility attributes

## Changes
- Modified `src/components/layout/footer.tsx` to include the GitHub link
- Added lucide-react Github icon import
- Used Next.js Link component for proper routing
- Centered the link in the footer container

## Testing
- All CI checks passed (lint, format, tests)
- Link opens in new tab with proper security attributes
- Responsive design works across viewport sizes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A GitHub link has been added to the footer, featuring a recognisable icon and comprehensive accessibility attributes to ensure inclusivity for all users. The implementation includes responsive hover styling for improved visual feedback and interactive experience. The link opens in a new tab, preserving the user's context within the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->